### PR TITLE
Read and clode response body after each retry

### DIFF
--- a/storage/client.go
+++ b/storage/client.go
@@ -120,6 +120,7 @@ func (ds *DefaultSender) Send(c *Client, req *http.Request) (resp *http.Response
 		if err != nil || !autorest.ResponseHasStatusCode(resp, ds.ValidStatusCodes...) {
 			return resp, err
 		}
+		readAndCloseBody(resp.Body)
 		autorest.DelayForBackoff(ds.RetryDuration, attempts, req.Cancel)
 		ds.attempts = attempts
 	}


### PR DESCRIPTION
The only change here is when returned error is nil (the Response is guaranteed to contain a non-nil Body); in other cases throughout the code, readAndCloseBody is already called.

Without this fix, retries will cause connection leaks

Fixes issue https://github.com/Azure/azure-sdk-for-go/issues/1500